### PR TITLE
Changed manifests to support KNIME 3.x

### DIFF
--- a/de.openms.knime.mzTab/META-INF/MANIFEST.MF
+++ b/de.openms.knime.mzTab/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Require-Bundle: org.eclipse.core.runtime,
  org.knime.workbench.core,
  org.knime.workbench.repository,
- org.knime.base,org.knime.base.filehandling;bundle-version="[2.7.2,3.0.0)",
- org.knime.core.data.uritype;bundle-version="[2.7.0,3.0.0)"
+ org.knime.base,org.knime.base.filehandling;bundle-version="[3.0.0,4.0.0)",
+ org.knime.core.data.uritype;bundle-version="[3.0.0,4.0.0)"
 Bundle-Vendor: The OpenMS Team
 Bundle-ActivationPolicy: lazy
 Bundle-Version: 0.1.0.qualifier

--- a/de.openms.knime.startupCheck/META-INF/MANIFEST.MF
+++ b/de.openms.knime.startupCheck/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.10.0.qualifier
 Bundle-Activator: de.openms.knime.startupcheck.Activator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.6.0,4.0.0)",
- org.knime.workbench.core;bundle-version="[2.10.1,3.0.0)",
- org.knime.workbench.ui;bundle-version="[2.10.1,3.0.0)"
+ org.knime.workbench.core;bundle-version="[3.0.0,4.0.0)",
+ org.knime.workbench.ui;bundle-version="[3.0.0,4.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/de.openms.knime.textexporter_reader/META-INF/MANIFEST.MF
+++ b/de.openms.knime.textexporter_reader/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Require-Bundle: org.eclipse.core.runtime,
  org.knime.workbench.core,
  org.knime.workbench.repository,
- org.knime.base.filehandling;bundle-version="[2.7.2,3.0.0)",
- org.knime.core.data.uritype;bundle-version="[2.7.0,3.0.0)"
+ org.knime.base.filehandling;bundle-version="[3.0.0,4.0.0)",
+ org.knime.core.data.uritype;bundle-version="[3.0.0,4.0.0)"
 Bundle-Vendor: The OpenMS Team
 Bundle-ActivationPolicy: lazy
 Bundle-Version: 0.1.0.qualifier


### PR DESCRIPTION
Can we create a new tag or branch for this, so our build machines can checkout the correct one?

Is a bit related to #5. We need to think about a good synchronizing scheme for KNIME, GKN, the contrib plugins de.openms/de.seqan and the libraries itself OpenMS/SeqAn.
