### PR TITLE
Extends some version ranges for dependencies to be future proof. 

### DIFF
--- a/de.openms.knime.importers/META-INF/MANIFEST.MF
+++ b/de.openms.knime.importers/META-INF/MANIFEST.MF
@@ -5,12 +5,12 @@ Bundle-SymbolicName: de.openms.knime.importers;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Bundle-Vendor: Alexander Fillbrunn
 Require-Bundle: org.knime.base;bundle-version="[3.0.0,5.0.0)",
- javax.activation;bundle-version="1.1.0",
+ javax.activation;bundle-version="[1.1.0,2.0.0)",
  com.genericworkflownodes.knime;bundle-version="[0.8.0,2.0.0)",
- org.apache.log4j;bundle-version="1.2.15",
- org.apache.commons.io;bundle-version="2.4.0",
- org.apache.commons.codec;bundle-version="1.6.0",
- org.slf4j.api;bundle-version="1.7.2"
+ org.apache.log4j;bundle-version="[1.2.15,2.0.0)",
+ org.apache.commons.io;bundle-version="[2.4.0,3.0.0)",
+ org.apache.commons.codec;bundle-version="[1.6.0,2.0.0)",
+ org.slf4j.api;bundle-version="[1.7.2,2.0.0)"
 Eclipse-RegisterBuddy: org.knime.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: bin/,


### PR DESCRIPTION
Will be checked by CI if it breaks at some point when KNIME upgrades what they ship in their update site.